### PR TITLE
fix generation of dhparams in alpine branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:stable-alpine
 
-RUN runtimeDeps='inotify-tools bash' \
+RUN runtimeDeps='inotify-tools bash openssl' \
         && apk update && apk upgrade && apk add $runtimeDeps
 
 COPY letsencryptauth.conf /etc/nginx/snippets/letsencryptauth.conf


### PR DESCRIPTION
> dhparam file /etc/nginx/dhparam/dhparam.pem does not exist. Generating one with 4086 bit. This will take a while...
> /entrypoint.sh: line 21: openssl: command not found
> Could not generate dhparam file
